### PR TITLE
Remove roboto dependency from paper-styles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
   ],
   "dependencies": {
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
-    "font-roboto": "PolymerElements/font-roboto#^1.0.1",
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {

--- a/classes/typography.html
+++ b/classes/typography.html
@@ -7,7 +7,6 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<link rel="import" href="../../font-roboto/roboto.html">
 
 <!--
 Typographic styles are provided matching the Material Design standard styles:

--- a/typography.html
+++ b/typography.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../font-roboto/roboto.html">
 
 <style is="custom-style">
 


### PR DESCRIPTION
The roboto font is a dependency on a hard-coded CDN. Applications can
add the dependency and include the font as needed, rather than rely
paper-styles, which is used extensively throughout the Polymer
components. This is similar to other fonts listed in default styles
that might not be available on a system by default, but can be
resolved externally at the application level.

This change does not provide backward compatibility or a deprecation
period.